### PR TITLE
docs: rename section headers using private/public

### DIFF
--- a/source-templates/c-template/c_header.h
+++ b/source-templates/c-template/c_header.h
@@ -8,12 +8,12 @@
 #define C_HEADER_H_
 
 /*----------------------------------------------------------------------------*/
-/*                                Definitions                                 */
+/*                             Public Definitions                             */
 /*----------------------------------------------------------------------------*/
 typedef struct TriangularBufferStruct * TriangularBuffer;
 
 /*----------------------------------------------------------------------------*/
-/*                       Exportable Function Prototypes                       */
+/*                         Public Function Prototypes                         */
 /*----------------------------------------------------------------------------*/
 void addItemTriangularBuffer(TriangularBuffer bufferInstance, uint32_t newItem);
 uint32_t removeItemTriangularBuffer(TriangularBuffer bufferInstance);

--- a/source-templates/c-template/c_source.c
+++ b/source-templates/c-template/c_source.c
@@ -20,7 +20,7 @@
 /* keep empty */
 
 /*----------------------------------------------------------------------------*/
-/*                              Filescope Globals                             */
+/*                               Private Globals                              */
 /*----------------------------------------------------------------------------*/
 enum triangularBufferConstants {
     SPECIAL_INDEX = 0u,
@@ -44,12 +44,12 @@ static const char[] SOME_STRING = "a constant string";
 /* none */
 
 /*----------------------------------------------------------------------------*/
-/*                              Helper Prototypes                             */
+/*                         Private Function Prototypes                        */
 /*----------------------------------------------------------------------------*/
 static uint32_t privateFunctionName(uint32_t argumentName);
 
 /*----------------------------------------------------------------------------*/
-/*                       Exportable Function Definitions                      */
+/*                         Public Function Definitions                        */
 /*----------------------------------------------------------------------------*/
 void addItemTriangularBuffer(TriangularBuffer bufferInstance, uint32_t newItem)
 {
@@ -69,7 +69,7 @@ uint32_t removeItemTriangularBuffer(TriangularBuffer bufferInstance)
 }
 
 /*----------------------------------------------------------------------------*/
-/*                             Helper Definitions                             */
+/*                        Private Function Definitions                        */
 /*----------------------------------------------------------------------------*/
 static uint32_t privateFunctionName(uint32_t argumentName)
 {

--- a/source-templates/c-template/main.c
+++ b/source-templates/c-template/main.c
@@ -17,17 +17,17 @@
 /* keep empty */
 
 /*----------------------------------------------------------------------------*/
-/*                              Filescope Globals                             */
+/*                               Private Globals                              */
 /*----------------------------------------------------------------------------*/
 static const int32_t ANOTHER_CONSTANT = -9000;
 
 /*----------------------------------------------------------------------------*/
-/*                              Helper Prototypes                             */
+/*                         Private Function Prototypes                        */
 /*----------------------------------------------------------------------------*/
 static int32_t privateFunctionName(char* argumentName);
 
 /*----------------------------------------------------------------------------*/
-/*                             Helper Definitions                             */
+/*                        Private Function Definitions                        */
 /*----------------------------------------------------------------------------*/
 static int32_t privateFunctionName(const char* argumentName)
 {


### PR DESCRIPTION
edit c source template section headers from using helper/exportable words to -> private/public